### PR TITLE
Implement copy_divine_hooks and define loyalty_hook

### DIFF
--- a/3411967296/common/hook_types/divine_hooks.txt
+++ b/3411967296/common/hook_types/divine_hooks.txt
@@ -1,7 +1,11 @@
-﻿medium_boon = {
+medium_boon = {
 	expiration_days = 3650
 }
 
 major_boon = {
+	strong = yes
+}
+
+loyalty_hook = {
 	strong = yes
 }

--- a/3411967296/common/scripted_effects/return_effects.txt
+++ b/3411967296/common/scripted_effects/return_effects.txt
@@ -2,7 +2,6 @@ cure_bad_condition_for_return = {
     heal_effect = yes
 }
 
-#TODO
 copy_divine_hooks = {
     if = {
         limit = { 
@@ -214,6 +213,7 @@ basic_return = {
             }
             copy_blessings = yes
             copy_curses = yes
+            copy_divine_hooks = yes
             copy_prayer_management = yes				 
             
             if = {

--- a/3411967296/localization/english/divine_hook_types_l_english.yml
+++ b/3411967296/localization/english/divine_hook_types_l_english.yml
@@ -1,3 +1,4 @@
-﻿l_english:
+l_english:
  medium_boon: "Medium Boon"
  major_boon: "Major Boon"
+ loyalty_hook: "Loyalty Hook"


### PR DESCRIPTION
This PR addresses the TODO marker for `copy_divine_hooks` in `return_effects.txt`. 

Changes include:
1.  **New Hook Definition**: Created `loyalty_hook` as a strong hook in `divine_hooks.txt` to be used by the script.
2.  **Localization**: Added "Loyalty Hook" string to `divine_hook_types_l_english.yml`.
3.  **Implementation**: Enabled `copy_divine_hooks` within the `basic_return` scripted effect, ensuring that divine hooks (specifically the loyalty hook and binder relationship) are transferred or re-established upon character return.

This ensures the `copy_divine_hooks` logic is actually executed and has the necessary hook type defined to function correctly.

---
*PR created automatically by Jules for task [910971088449540193](https://jules.google.com/task/910971088449540193) started by @Bloodwarrior*