### PR TITLE
Fix invalid modifier syntax in interactions and decisions

### DIFF
--- a/3411967296/common/character_interactions/divine_domain_interactions.txt
+++ b/3411967296/common/character_interactions/divine_domain_interactions.txt
@@ -23,8 +23,8 @@ plague_eruption_interaction = {
         on_accept = {
                 scope:target = {
                         add_county_modifier = {
-                                name = plague_outbreak_modifier
-                                duration = 10y
+                                modifier = plague_outbreak_modifier
+                                years = 10
                         }
                 }
         }
@@ -51,8 +51,8 @@ love_forsaken_interaction = {
         on_accept = {
                 scope:recipient = {
                         add_character_modifier = {
-                                name = love_forsaken_modifier
-                                duration = 10y
+                                modifier = love_forsaken_modifier
+                                years = 10
                         }
                         add_opinion = {
                                 target = scope:actor

--- a/3411967296/common/decisions/divine_decisions.txt
+++ b/3411967296/common/decisions/divine_decisions.txt
@@ -34,7 +34,7 @@ embrace_plague_domain_decision = {
         }
 
         effect = {
-                add_character_modifier = { name = plague_domain_modifier duration = -1 }
+                add_character_modifier = plague_domain_modifier
         }
 }
 
@@ -53,6 +53,6 @@ embrace_love_domain_decision = {
         }
 
         effect = {
-                add_character_modifier = { name = love_domain_modifier duration = -1 }
+                add_character_modifier = love_domain_modifier
         }
 }


### PR DESCRIPTION
Identified and corrected syntax errors in script files where CK2-style or invalid syntax was used for adding character and county modifiers. Specifically:
- In `common/decisions/divine_decisions.txt`, replaced `add_character_modifier = { name = ... duration = -1 }` with `add_character_modifier = ...` to correctly apply permanent modifiers.
- In `common/character_interactions/divine_domain_interactions.txt`, corrected `add_county_modifier` and `add_character_modifier` blocks to use `modifier =` and `years =` keys instead of `name =` and `duration =`. Also corrected invalid `10y` value to integer `10`.

---
*PR created automatically by Jules for task [18045384769251642476](https://jules.google.com/task/18045384769251642476) started by @Bloodwarrior*