### PR TITLE
Add Divine Stances: Pantheon and Monotheism

### DIFF
--- a/3411967296/common/decisions/divine_stance_decisions.txt
+++ b/3411967296/common/decisions/divine_stance_decisions.txt
@@ -1,0 +1,95 @@
+adopt_pantheon_stance_decision = {
+    picture = {
+        reference = "gfx/interface/illustrations/decisions/decision_personal_religious.dds"
+    }
+    desc = adopt_pantheon_stance_decision_desc
+    selection_tooltip = adopt_pantheon_stance_decision_tooltip
+
+    is_shown = {
+        is_a_divinity = yes
+    }
+
+    is_valid = {
+        NOT = { has_character_flag = divine_is_pantheon }
+    }
+
+    cooldown = { years = 10 }
+
+    effect = {
+        add_character_flag = divine_is_pantheon
+        remove_character_flag = divine_is_monotheist
+        add_character_modifier = divine_stance_pantheon_modifier
+        if = {
+            limit = { has_character_modifier = divine_stance_monotheist_modifier }
+            remove_character_modifier = divine_stance_monotheist_modifier
+        }
+    }
+
+    ai_potential = {
+        is_a_divinity = yes
+    }
+
+    ai_will_do = {
+        base = 10
+        modifier = {
+            add = 20
+            faith = {
+                has_doctrine = doctrine_pluralism_pluralistic
+            }
+        }
+        modifier = {
+            factor = 0
+            faith = {
+                has_doctrine = doctrine_pluralism_fundamentalist
+            }
+        }
+    }
+}
+
+adopt_monotheist_stance_decision = {
+    picture = {
+        reference = "gfx/interface/illustrations/decisions/decision_personal_religious.dds"
+    }
+    desc = adopt_monotheist_stance_decision_desc
+    selection_tooltip = adopt_monotheist_stance_decision_tooltip
+
+    is_shown = {
+        is_a_divinity = yes
+    }
+
+    is_valid = {
+        NOT = { has_character_flag = divine_is_monotheist }
+    }
+
+    cooldown = { years = 10 }
+
+    effect = {
+        add_character_flag = divine_is_monotheist
+        remove_character_flag = divine_is_pantheon
+        add_character_modifier = divine_stance_monotheist_modifier
+        if = {
+            limit = { has_character_modifier = divine_stance_pantheon_modifier }
+            remove_character_modifier = divine_stance_pantheon_modifier
+        }
+    }
+
+    ai_potential = {
+        is_a_divinity = yes
+    }
+
+    ai_will_do = {
+        base = 10
+        modifier = {
+            add = 20
+            faith = {
+                has_doctrine = doctrine_pluralism_fundamentalist
+            }
+        }
+        modifier = {
+            factor = 0
+            faith = {
+                has_doctrine = doctrine_pluralism_pluralistic
+            }
+        }
+    }
+}

--- a/3411967296/common/modifiers/divine_stance_modifiers.txt
+++ b/3411967296/common/modifiers/divine_stance_modifiers.txt
@@ -1,0 +1,13 @@
+divine_stance_pantheon_modifier = {
+    icon = diplomacy_positive
+    diplomacy = 2
+    learning = 2
+    general_opinion = 5
+}
+
+divine_stance_monotheist_modifier = {
+    icon = stewardship_positive
+    stewardship = 2
+    martial = 2
+    monthly_piety = 1
+}

--- a/3411967296/common/scripted_effects/prayer_effects.txt
+++ b/3411967296/common/scripted_effects/prayer_effects.txt
@@ -41,7 +41,36 @@
 
 gave_minor_boon = {
 	if = {
-		limit = { NOT = { scope:petitioner.faith = scope:divinity.faith } }
+		limit = {
+			NOT = { scope:petitioner.faith = scope:divinity.faith }
+			OR = {
+				# Monotheist: Always convert
+				scope:divinity = { has_character_flag = divine_is_monotheist }
+
+				# Pantheon: Convert if Evil
+				AND = {
+					scope:divinity = { has_character_flag = divine_is_pantheon }
+					scope:divinity.faith = {
+						faith_hostility_level = {
+							target = scope:petitioner.faith
+							value >= faith_evil_level
+						}
+					}
+				}
+
+				# Default: Convert if Hostile or Evil
+				AND = {
+					NOT = { scope:divinity = { has_character_flag = divine_is_monotheist } }
+					NOT = { scope:divinity = { has_character_flag = divine_is_pantheon } }
+					scope:divinity.faith = {
+						faith_hostility_level = {
+							target = scope:petitioner.faith
+							value >= faith_hostile_level
+						}
+					}
+				}
+			}
+		}
 		scope:petitioner = {
 			set_character_faith_with_conversion = scope:divinity.faith
 		}
@@ -56,7 +85,36 @@ gave_minor_boon = {
 
 gave_medium_boon = {
 	if = {
-		limit = { NOT = { scope:petitioner.faith = scope:divinity.faith } }
+		limit = {
+			NOT = { scope:petitioner.faith = scope:divinity.faith }
+			OR = {
+				# Monotheist: Always convert
+				scope:divinity = { has_character_flag = divine_is_monotheist }
+
+				# Pantheon: Convert if Evil
+				AND = {
+					scope:divinity = { has_character_flag = divine_is_pantheon }
+					scope:divinity.faith = {
+						faith_hostility_level = {
+							target = scope:petitioner.faith
+							value >= faith_evil_level
+						}
+					}
+				}
+
+				# Default: Convert if Hostile or Evil
+				AND = {
+					NOT = { scope:divinity = { has_character_flag = divine_is_monotheist } }
+					NOT = { scope:divinity = { has_character_flag = divine_is_pantheon } }
+					scope:divinity.faith = {
+						faith_hostility_level = {
+							target = scope:petitioner.faith
+							value >= faith_hostile_level
+						}
+					}
+				}
+			}
+		}
 		scope:petitioner = {
 			set_character_faith_with_conversion = scope:divinity.faith
 		}
@@ -75,7 +133,36 @@ gave_medium_boon = {
 
 gave_major_boon = {
 	if = {
-		limit = { NOT = { scope:petitioner.faith = scope:divinity.faith } }
+		limit = {
+			NOT = { scope:petitioner.faith = scope:divinity.faith }
+			OR = {
+				# Monotheist: Always convert
+				scope:divinity = { has_character_flag = divine_is_monotheist }
+
+				# Pantheon: Convert if Evil
+				AND = {
+					scope:divinity = { has_character_flag = divine_is_pantheon }
+					scope:divinity.faith = {
+						faith_hostility_level = {
+							target = scope:petitioner.faith
+							value >= faith_evil_level
+						}
+					}
+				}
+
+				# Default: Convert if Hostile or Evil
+				AND = {
+					NOT = { scope:divinity = { has_character_flag = divine_is_monotheist } }
+					NOT = { scope:divinity = { has_character_flag = divine_is_pantheon } }
+					scope:divinity.faith = {
+						faith_hostility_level = {
+							target = scope:petitioner.faith
+							value >= faith_hostile_level
+						}
+					}
+				}
+			}
+		}
 		scope:petitioner = {
 			set_character_faith_with_conversion = scope:divinity.faith
 		}

--- a/3411967296/events/divine_prayer_events.txt
+++ b/3411967296/events/divine_prayer_events.txt
@@ -7,7 +7,7 @@ namespace = divine_prayer
 # 	theme = faith
 
 # 	left_portrait = root
-	
+
 # 	right_portrait = scope:petitioner
 
 # 	immediate = {
@@ -17,7 +17,7 @@ namespace = divine_prayer
 # 			save_scope_as = recipient
 # 		}
 # 	}
-	
+
 # 	# minor boon
 # 	option = {
 # 		name = divine_prayer.0001.a
@@ -47,7 +47,7 @@ namespace = divine_prayer
 # 		show_as_unavailable = {always = yes}
 # 		gave_major_boon = yes
 # 	}
-	
+
 # 	option = {
 # 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -55,9 +55,9 @@ namespace = divine_prayer
 # 			if = {
 # 				limit = { scope:petitioner.faith = scope:divnity.faith }
 # 				check_for_heresy = yes
-# 			}			
+# 			}
 # 		}
-		
+
 # 	}
 # }
 
@@ -120,12 +120,12 @@ divine_prayer.9000 = {
 						target = scope:divinity
 						modifier = refused_boon
 					}
-					
+
 				}
 				else = {
 					choose_prayer_effect = yes
 				}
-				
+
 			}
 		}
 	}
@@ -188,7 +188,19 @@ divine_prayer.9001 = {
 							value >= faith_hostile_level
 						}
 					}
-					
+
+				}
+				modifier = {
+					factor = 2.0
+					scope:divinity = {
+						has_character_flag = divine_is_pantheon
+					}
+					faith = {
+						faith_hostility_level = {
+							target = scope:divinity.faith
+							value < faith_hostile_level
+						}
+					}
 				}
 				modifier = {
 					factor = 0.1
@@ -198,9 +210,9 @@ divine_prayer.9001 = {
 							value >= faith_evil_level
 						}
 					}
-					
+
 				}
-				
+
 			}
 			save_scope_as = petitioner
 				if = {
@@ -217,13 +229,13 @@ divine_prayer.9001 = {
 						target = scope:divinity
 						modifier = refused_boon
 					}
-					
+
 				}
 				else = {
 					choose_prayer_effect = yes
 				}
 		}
-		
+
 	}
 }
 
@@ -235,7 +247,7 @@ divine_prayer.0001 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -245,7 +257,7 @@ divine_prayer.0001 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -291,7 +303,7 @@ divine_prayer.0001 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -303,9 +315,9 @@ divine_prayer.0001 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -316,7 +328,7 @@ divine_prayer.0002 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -326,7 +338,7 @@ divine_prayer.0002 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -372,7 +384,7 @@ divine_prayer.0002 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -384,9 +396,9 @@ divine_prayer.0002 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -397,7 +409,7 @@ divine_prayer.0003 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -407,7 +419,7 @@ divine_prayer.0003 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -453,7 +465,7 @@ divine_prayer.0003 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -465,9 +477,9 @@ divine_prayer.0003 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -478,7 +490,7 @@ divine_prayer.0004 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -488,7 +500,7 @@ divine_prayer.0004 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -534,7 +546,7 @@ divine_prayer.0004 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -546,9 +558,9 @@ divine_prayer.0004 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -559,7 +571,7 @@ divine_prayer.0005 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -569,7 +581,7 @@ divine_prayer.0005 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -615,7 +627,7 @@ divine_prayer.0005 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -627,9 +639,9 @@ divine_prayer.0005 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -640,7 +652,7 @@ divine_prayer.0006 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -650,7 +662,7 @@ divine_prayer.0006 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -696,7 +708,7 @@ divine_prayer.0006 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -708,9 +720,9 @@ divine_prayer.0006 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -722,7 +734,7 @@ divine_prayer.0007 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -732,7 +744,7 @@ divine_prayer.0007 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.0001.a
@@ -778,7 +790,7 @@ divine_prayer.0007 = {
 	# 	name = divine_prayer.0001.c
 	# 	gave_major_boon = yes
 	# }
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -790,9 +802,9 @@ divine_prayer.0007 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -804,7 +816,7 @@ divine_prayer.1000 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -814,7 +826,7 @@ divine_prayer.1000 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# Reborn
 	option = {
 		name = divine_prayer.1000.a
@@ -874,7 +886,7 @@ divine_prayer.1000 = {
 		show_as_unavailable = {always = yes}
 		gave_major_boon = yes
 	}
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -886,9 +898,9 @@ divine_prayer.1000 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -900,7 +912,7 @@ divine_prayer.2000 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -910,7 +922,7 @@ divine_prayer.2000 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.2000.a
@@ -935,7 +947,7 @@ divine_prayer.2000 = {
 			scope:recipient = {
 				can_increase_trait_by = { AMOUNT = 2 TRAIT = intellect}
 			}
-			
+
 		}
 		show_as_unavailable = {always = yes}
 		scope:divinity = {
@@ -955,7 +967,7 @@ divine_prayer.2000 = {
 			scope:recipient = {
 				can_increase_trait_by = { AMOUNT = 3 TRAIT = intellect}
 			}
-			
+
 		}
 		show_as_unavailable = {always = yes}
 		scope:divinity = {
@@ -966,7 +978,7 @@ divine_prayer.2000 = {
 		}
 		gave_major_boon = yes
 	}
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -978,9 +990,9 @@ divine_prayer.2000 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -993,7 +1005,7 @@ divine_prayer.2001 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -1003,7 +1015,7 @@ divine_prayer.2001 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.2001.a
@@ -1028,7 +1040,7 @@ divine_prayer.2001 = {
 			scope:recipient = {
 				can_increase_trait_by = { AMOUNT = 2 TRAIT = beauty}
 			}
-			
+
 		}
 		show_as_unavailable = {always = yes}
 		scope:divinity = {
@@ -1048,7 +1060,7 @@ divine_prayer.2001 = {
 			scope:recipient = {
 				can_increase_trait_by = { AMOUNT = 3 TRAIT = beauty}
 			}
-			
+
 		}
 		show_as_unavailable = {always = yes}
 		scope:divinity = {
@@ -1059,7 +1071,7 @@ divine_prayer.2001 = {
 		}
 		gave_major_boon = yes
 	}
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -1071,9 +1083,9 @@ divine_prayer.2001 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -1085,7 +1097,7 @@ divine_prayer.2002 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -1095,7 +1107,7 @@ divine_prayer.2002 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.2002.a
@@ -1120,7 +1132,7 @@ divine_prayer.2002 = {
 			scope:recipient = {
 				can_increase_trait_by = { AMOUNT = 2 TRAIT = physique}
 			}
-			
+
 		}
 		show_as_unavailable = {always = yes}
 		scope:divinity = {
@@ -1140,7 +1152,7 @@ divine_prayer.2002 = {
 			scope:recipient = {
 				can_increase_trait_by = { AMOUNT = 3 TRAIT = physique}
 			}
-			
+
 		}
 		show_as_unavailable = {always = yes}
 		scope:divinity = {
@@ -1151,7 +1163,7 @@ divine_prayer.2002 = {
 		}
 		gave_major_boon = yes
 	}
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -1163,9 +1175,9 @@ divine_prayer.2002 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -1177,7 +1189,7 @@ divine_prayer.2003 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -1187,7 +1199,7 @@ divine_prayer.2003 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.2003.a
@@ -1204,7 +1216,7 @@ divine_prayer.2003 = {
 		gave_minor_boon = yes
 	}
 
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -1216,9 +1228,9 @@ divine_prayer.2003 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -1230,7 +1242,7 @@ divine_prayer.2004 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -1240,7 +1252,7 @@ divine_prayer.2004 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.2004.a
@@ -1257,7 +1269,7 @@ divine_prayer.2004 = {
 		gave_minor_boon = yes
 	}
 
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -1269,9 +1281,9 @@ divine_prayer.2004 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -1282,7 +1294,7 @@ divine_prayer.2005 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -1292,7 +1304,7 @@ divine_prayer.2005 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# minor boon
 	option = {
 		name = divine_prayer.2005.a
@@ -1309,7 +1321,7 @@ divine_prayer.2005 = {
 		gave_minor_boon = yes
 	}
 
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -1321,9 +1333,9 @@ divine_prayer.2005 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }
 
@@ -1335,7 +1347,7 @@ divine_prayer.3000 = {
 	theme = faith
 
 	left_portrait = root
-	
+
 	right_portrait = scope:petitioner
 
 	immediate = {
@@ -1345,7 +1357,7 @@ divine_prayer.3000 = {
 			save_scope_as = recipient
 		}
 	}
-	
+
 	# Medium boon
 	option = {
 		name = divine_prayer.3000.a
@@ -1361,7 +1373,7 @@ divine_prayer.3000 = {
 				men_at_arms = {
 					type = divine_armored_footmen
 					stacks = 5
-				} 
+				}
 				location = location
 				name = DIVINE_ARMY
 			}
@@ -1385,7 +1397,7 @@ divine_prayer.3000 = {
 				men_at_arms = {
 					type = divine_bowmen
 					stacks = 5
-				} 
+				}
 				location = location
 				name = DIVINE_ARMY
 			}
@@ -1409,7 +1421,7 @@ divine_prayer.3000 = {
 				men_at_arms = {
 					type = divine_armored_horsemen
 					stacks = 5
-				} 
+				}
 				location = location
 				name = DIVINE_ARMY
 			}
@@ -1433,7 +1445,7 @@ divine_prayer.3000 = {
 				men_at_arms = {
 					type = divine_titan
 					stacks = 1
-				} 
+				}
 				location = location
 				name = DIVINE_ARMY
 			}
@@ -1441,7 +1453,7 @@ divine_prayer.3000 = {
 		show_as_unavailable = {always = yes}
 		gave_major_boon = yes
 	}
-	
+
 	option = {
 		name = divine_prayer.0001.d
         ai_chance = { base = 0 }
@@ -1453,8 +1465,8 @@ divine_prayer.3000 = {
 			add_opinion = {
 				target = scope:divinity
 				modifier = refused_boon
-			}			
+			}
 		}
-		
+
 	}
 }

--- a/3411967296/localization/english/divine_stance_l_english.yml
+++ b/3411967296/localization/english/divine_stance_l_english.yml
@@ -1,0 +1,11 @@
+l_english:
+ divine_stance_pantheon_modifier:0 "Pantheon Stance"
+ divine_stance_monotheist_modifier:0 "Monotheist Stance"
+
+ adopt_pantheon_stance_decision:0 "Adopt Pantheon Stance"
+ adopt_pantheon_stance_decision_desc:0 "Open your divine embrace to the world. Accept prayers from those of other faiths, provided they are not evil. You will become a god of the many."
+ adopt_pantheon_stance_decision_tooltip:0 "You will adopt the [GetModifier('divine_stance_pantheon_modifier').GetNameWithTooltip] modifier and allow prayers from compatible faiths without forced conversion."
+
+ adopt_monotheist_stance_decision:0 "Adopt Monotheist Stance"
+ adopt_monotheist_stance_decision_desc:0 "Declare yourself the one true god. Demand absolute submission and conversion from all who seek your favor."
+ adopt_monotheist_stance_decision_tooltip:0 "You will adopt the [GetModifier('divine_stance_monotheist_modifier').GetNameWithTooltip] modifier and force conversion on all petitioners."


### PR DESCRIPTION
This update adds depth to the religious gameplay for Divinity characters. You can now choose to be a tolerant member of a Pantheon or a strict Monotheist god.
- **Pantheon Stance**: Increases Diplomacy and Learning. You will accept prayers from other faiths (unless they are Evil) without forcing them to convert. You are also more likely to be petitioned by foreign rulers.
- **Monotheist Stance**: Increases Stewardship and Martial. You demand absolute submission (forced conversion) from anyone who prays to you.

This addresses the request for "more ways and different religions connection to the gods such as pantheons or monotheism".

---
*PR created automatically by Jules for task [13698400618418056430](https://jules.google.com/task/13698400618418056430) started by @Bloodwarrior*