### PR TITLE
Add Ultimate Abilities for Divine Domains

### DIFF
--- a/3411967296/common/character_interactions/divine_ultimate_interactions.txt
+++ b/3411967296/common/character_interactions/divine_ultimate_interactions.txt
@@ -1,0 +1,141 @@
+plague_apocalypse_interaction = {
+	category = interaction_category_religion
+	icon = cataclysm
+	interface_priority = 90
+
+	desc = plague_apocalypse_interaction_desc
+
+	target_type = title
+	target_filter = recipient_domain_titles
+
+	is_shown = {
+		scope:actor = {
+			is_a_divinity = yes
+			has_character_modifier = plague_domain_modifier
+		}
+		scope:recipient = { is_landed = yes }
+	}
+
+	can_be_picked = {
+		scope:target = { tier = tier_county }
+	}
+
+	on_accept = {
+		scope:target = {
+			add_county_modifier = {
+				modifier = plague_apocalypse_modifier
+				years = 50
+			}
+			change_development_level = -50
+		}
+		scope:target.holder = {
+			if = {
+				limit = { NOT = { has_trait = bubonic_plague } }
+				add_trait = bubonic_plague
+			}
+		}
+	}
+
+	auto_accept = yes
+	cost = { piety = 500 }
+}
+
+love_obsession_interaction = {
+	category = interaction_category_religion
+	icon = magic_positive
+	interface_priority = 90
+
+	desc = love_obsession_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			is_a_divinity = yes
+			has_character_modifier = love_domain_modifier
+		}
+		NOT = { scope:actor = scope:recipient }
+	}
+
+	on_accept = {
+		scope:recipient = {
+			set_character_faith = scope:actor.faith
+			add_character_modifier = {
+				modifier = divine_obsession_modifier
+				years = 50
+			}
+			add_opinion = {
+				target = scope:actor
+				modifier = divine_obsession_opinion
+			}
+		}
+	}
+
+	auto_accept = yes
+	cost = { piety = 500 }
+}
+
+time_collapse_interaction = {
+	category = interaction_category_religion
+	icon = curse
+	interface_priority = 90
+
+	desc = time_collapse_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			is_a_divinity = yes
+			has_character_modifier = time_domain_modifier
+		}
+		NOT = { scope:actor = scope:recipient }
+	}
+
+	on_accept = {
+		scope:recipient = {
+			add_trait = infirm
+			add_stress = 300
+			add_character_modifier = {
+				modifier = time_collapse_modifier
+				years = 10
+			}
+		}
+	}
+
+	auto_accept = yes
+	cost = { piety = 500 }
+}
+
+nature_reclamation_interaction = {
+	category = interaction_category_religion
+	icon = cataclysm
+	interface_priority = 90
+
+	desc = nature_reclamation_interaction_desc
+
+	target_type = title
+	target_filter = recipient_domain_titles
+
+	is_shown = {
+		scope:actor = {
+			is_a_divinity = yes
+			has_character_modifier = nature_domain_modifier
+		}
+		scope:recipient = { is_landed = yes }
+	}
+
+	can_be_picked = {
+		scope:target = { tier = tier_county }
+	}
+
+	on_accept = {
+		scope:target = {
+			add_county_modifier = {
+				modifier = wild_reclamation_modifier
+				years = 50
+			}
+			change_county_control = -100
+			change_development_level = -20
+		}
+	}
+
+	auto_accept = yes
+	cost = { piety = 500 }
+}

--- a/3411967296/common/modifiers/divine_ultimate_modifiers.txt
+++ b/3411967296/common/modifiers/divine_ultimate_modifiers.txt
@@ -1,0 +1,34 @@
+plague_apocalypse_modifier = {
+	icon = magic_negative
+	levy_size = -1
+	tax_mult = -1
+	development_growth = -10
+	supply_limit_mult = -0.9
+	epidemic_resistance = -50
+	stacking = yes
+}
+
+divine_obsession_modifier = {
+	icon = diplomacy_positive
+	fertility = 2.0
+	diplomacy = 10
+	stewardship = -5
+	attraction_opinion = 50
+	stacking = yes
+}
+
+wild_reclamation_modifier = {
+	icon = martial_negative
+	monthly_county_control_growth = -5
+	tax_mult = -1
+	levy_size = -1
+	fort_level = 5
+	hostile_county_attrition = 20
+	stacking = yes
+}
+
+time_collapse_modifier = {
+	icon = health_negative
+	health = -5
+	stacking = yes
+}

--- a/3411967296/common/opinion_modifiers/divine_ultimate_opinion_modifiers.txt
+++ b/3411967296/common/opinion_modifiers/divine_ultimate_opinion_modifiers.txt
@@ -1,0 +1,4 @@
+divine_obsession_opinion = {
+	opinion = 100
+	decaying = no
+}

--- a/3411967296/localization/english/interactions/divine_ultimate_interactions_l_english.yml
+++ b/3411967296/localization/english/interactions/divine_ultimate_interactions_l_english.yml
@@ -1,0 +1,21 @@
+l_english:
+ plague_apocalypse_interaction: "Unleash Apocalyptic Plague"
+ plague_apocalypse_interaction_desc: "Unleash a plague so vile it will decimate the county, killing its population and leaving it a ruin for decades."
+ plague_apocalypse_modifier: "Apocalyptic Plague"
+ plague_apocalypse_modifier_desc: "This county is suffering from a divinely ordained plague. Few survive."
+
+ love_obsession_interaction: "Induce Divine Obsession"
+ love_obsession_interaction_desc: "Force the target into a state of divine obsession, making them your devoted soulmate and converting them to your faith."
+ divine_obsession_modifier: "Divine Obsession"
+ divine_obsession_modifier_desc: "This character is divinely obsessed with their deity."
+ divine_obsession_opinion: "Divinely Obsessed"
+
+ time_collapse_interaction: "Inflict Time Collapse"
+ time_collapse_interaction_desc: "Accelerate the target's aging process instantly, bringing them to the brink of death."
+ time_collapse_modifier: "Time Collapse"
+ time_collapse_modifier_desc: "This character's timeline has been shattered, resulting in rapid aging and failing health."
+
+ nature_reclamation_interaction: "Reclaim for Nature"
+ nature_reclamation_interaction_desc: "Command nature to reclaim this county, destroying infrastructure and making it hostile to civilization."
+ wild_reclamation_modifier: "Wild Reclamation"
+ wild_reclamation_modifier_desc: "Nature has reclaimed this land. It is wild, overgrown, and hostile to civilization."


### PR DESCRIPTION
Added "very powerful abilities" for Plague, Love, Time, and Nature domains.
- Plague: "Unleash Apocalyptic Plague" (Devastates county, infects holder).
- Love: "Induce Divine Obsession" (Soulmate, conversion, opinion boost).
- Time: "Inflict Time Collapse" (Ages target, applies infirmity).
- Nature: "Reclaim for Nature" (Destroys control/development, makes county wild).
Added associated modifiers and localization.

---
*PR created automatically by Jules for task [12349068124975394635](https://jules.google.com/task/12349068124975394635) started by @Bloodwarrior*