### PR TITLE
Implement The Token Pseudo-Divinity System

### DIFF
--- a/3411967296/common/character_interactions/token_interactions.txt
+++ b/3411967296/common/character_interactions/token_interactions.txt
@@ -1,0 +1,85 @@
+grant_pseudo_divinity_interaction = {
+    category = interaction_category_friendly
+    desc = grant_pseudo_divinity_interaction_desc
+
+    is_shown = {
+        scope:actor = { has_trait = token_bearer }
+        scope:recipient = {
+            is_close_family_of = scope:actor
+            NOT = { has_trait = token_pseudo_divine }
+        }
+    }
+
+    is_valid = {
+        scope:actor.dynasty = {
+            any_dynasty_member = {
+                count < 10
+                OR = {
+                    has_trait = token_pseudo_divine
+                    has_trait = token_pseudo_divine_withered
+                }
+            }
+        }
+    }
+
+    on_accept = {
+        scope:recipient = {
+            grant_pseudo_divinity_effect = yes
+        }
+    }
+}
+
+seize_token_interaction = {
+    category = interaction_category_hostile
+    desc = seize_token_interaction_desc
+
+    is_shown = {
+        scope:recipient = { has_trait = token_bearer }
+        scope:actor = {
+            NOT = { has_trait = token_bearer }
+            is_close_family_of = scope:recipient
+        }
+    }
+
+    is_valid = {
+        OR = {
+            scope:recipient = { has_modifier = token_drained_modifier }
+            scope:recipient = { is_imprisoned_by = scope:actor }
+            scope:recipient = { is_incapable = yes }
+            scope:actor = { prowess > scope:recipient.prowess }
+        }
+    }
+
+    cost = {
+        prestige = 1000
+    }
+
+    on_accept = {
+        scope:recipient = {
+            remove_trait = token_bearer
+            # Attempt to clear the old empire variable if possible
+            if = {
+                limit = {
+                    tier = tier_empire
+                    primary_title = { has_variable = is_token_empire }
+                }
+                primary_title = {
+                    remove_variable = is_token_empire
+                }
+            }
+        }
+        scope:actor = {
+            add_trait = token_bearer
+            add_trait = token_pseudo_divine
+            set_variable = { name = token_charge value = 100 }
+
+            # Rebind to new empire if Emperor
+            if = {
+                limit = { tier = tier_empire }
+                primary_title = {
+                    set_variable = { name = is_token_empire value = yes }
+                }
+            }
+        }
+    }
+}

--- a/3411967296/common/decisions/token_decisions.txt
+++ b/3411967296/common/decisions/token_decisions.txt
@@ -1,0 +1,133 @@
+found_token_decision = {
+    picture = "gfx/interface/illustrations/decisions/decision_destiny_goal.dds"
+    title = found_token_decision_title
+    desc = found_token_decision_desc
+    selection_tooltip = found_token_decision_tooltip
+
+    is_shown = {
+        tier = tier_empire
+        NOT = { has_trait = token_bearer }
+        NOT = { has_global_variable = token_created }
+    }
+
+    is_valid = {
+        prestige_level >= 3
+        piety_level >= 3
+        gold >= 500
+    }
+
+    cost = {
+        gold = 500
+        prestige = 1000
+    }
+
+    effect = {
+        set_global_variable = {
+            name = token_created
+            value = yes
+        }
+        create_token_effect = yes
+    }
+}
+
+token_ritual_decision = {
+    picture = "gfx/interface/illustrations/decisions/decision_religious_experience.dds"
+    title = token_ritual_decision_title
+    desc = token_ritual_decision_desc
+    selection_tooltip = token_ritual_decision_tooltip
+
+    is_shown = {
+        has_trait = token_bearer
+    }
+
+    is_valid = {
+        gold >= 100
+    }
+
+    cost = {
+        gold = 100
+        piety = 200
+    }
+
+    effect = {
+        change_variable = {
+            name = token_charge
+            add = 50
+        }
+        trigger_event = token.0010
+    }
+
+    ai_check_interval = 12
+    ai_will_do = {
+        base = 100
+        modifier = {
+            trigger = { var:token_charge < 50 }
+            add = 100
+        }
+    }
+}
+
+token_sacrifice_decision = {
+    picture = "gfx/interface/illustrations/decisions/decision_execution.dds"
+    title = token_sacrifice_decision_title
+    desc = token_sacrifice_decision_desc
+    selection_tooltip = token_sacrifice_decision_tooltip
+
+    is_shown = {
+        has_trait = token_bearer
+    }
+
+    is_valid = {
+        any_prisoner = {
+            is_alive = yes
+        }
+    }
+
+    effect = {
+        random_prisoner = {
+            death = {
+                death_reason = death_execution
+                killer = scope:actor
+            }
+        }
+        change_variable = {
+            name = token_charge
+            add = 100
+        }
+        trigger_event = token.0020
+    }
+
+    ai_check_interval = 12
+    ai_will_do = {
+        base = 0
+        modifier = {
+            trigger = { var:token_charge < 20 }
+            add = 200
+        }
+    }
+}
+
+destroy_token_decision = {
+    picture = "gfx/interface/illustrations/decisions/decision_realm_stability.dds"
+    title = destroy_token_decision_title
+    desc = destroy_token_decision_desc
+    selection_tooltip = destroy_token_decision_tooltip
+
+    is_shown = {
+        has_trait = token_bearer
+    }
+
+    effect = {
+        remove_trait = token_bearer
+        remove_trait = token_pseudo_divine
+        remove_global_variable = token_created
+
+        # Remove from dynasty members
+        scope:actor.dynasty = {
+            every_dynasty_member = {
+                remove_trait = token_pseudo_divine
+                remove_modifier = token_withered_modifier
+            }
+        }
+    }
+}

--- a/3411967296/common/modifiers/token_modifiers.txt
+++ b/3411967296/common/modifiers/token_modifiers.txt
@@ -1,0 +1,26 @@
+token_empowered_modifier = {
+    icon = "advantage"
+    monthly_prestige = 2
+    monthly_piety = 2
+    levy_reinforcement_rate = 0.2
+}
+
+token_drained_modifier = {
+    icon = "decline"
+    monthly_prestige = -5
+    monthly_piety = -5
+    health = -2
+    stress_gain_mult = 0.5
+}
+
+token_withered_modifier = {
+    icon = "death"
+    health = -10
+    prowess = -20
+    diplomacy = -10
+    stewardship = -10
+    martial = -10
+    intrigue = -10
+    learning = -10
+    fertility = -10.0
+}

--- a/3411967296/common/on_action/token_on_actions.txt
+++ b/3411967296/common/on_action/token_on_actions.txt
@@ -1,0 +1,11 @@
+yearly_global_pulse = {
+    on_actions = {
+        token_yearly_pulse
+    }
+}
+
+token_yearly_pulse = {
+    events = {
+        token.1000
+    }
+}

--- a/3411967296/common/scripted_effects/token_effects.txt
+++ b/3411967296/common/scripted_effects/token_effects.txt
@@ -1,0 +1,130 @@
+create_token_effect = {
+    # Binds the token to the current primary empire
+    primary_title = {
+        set_variable = {
+            name = is_token_empire
+            value = yes
+        }
+    }
+
+    # Initialize charge on the character
+    set_variable = {
+        name = token_charge
+        value = 100
+    }
+
+    add_trait = token_bearer
+    add_trait = token_pseudo_divine
+
+    # Trigger event
+    trigger_event = token.0001
+}
+
+check_token_region_effect = {
+    # Run on each pseudo-divine character
+
+    # Check if they are inside the bound empire
+    if = {
+        limit = {
+            exists = current_location
+            current_location = {
+                title_province = {
+                    empire = {
+                        has_variable = is_token_empire
+                    }
+                }
+            }
+        }
+        # Is inside
+        remove_modifier = token_withered_modifier
+
+        # Restore immortality if withered
+        if = {
+            limit = { has_trait = token_pseudo_divine_withered }
+            remove_trait = token_pseudo_divine_withered
+            add_trait = token_pseudo_divine
+        }
+    }
+    else = {
+        # Is outside
+        if = {
+            limit = {
+                NOT = { has_character_modifier = token_withered_modifier }
+            }
+            trigger_event = token.1001 # Warning
+        }
+        add_modifier = {
+            modifier = token_withered_modifier
+            years = 1
+        }
+
+        # Remove immortality logic
+        if = {
+            limit = { has_trait = token_pseudo_divine }
+            remove_trait = token_pseudo_divine
+            add_trait = token_pseudo_divine_withered
+        }
+
+        # Rapid aging logic
+        change_current_age = 5
+        add_stress = 20
+    }
+}
+
+update_token_charge_effect = {
+    # Run on the Token Bearer
+    if = {
+        limit = {
+            has_variable = token_charge
+        }
+        change_variable = {
+            name = token_charge
+            add = -5 # Decay
+        }
+
+        # Check thresholds
+        if = {
+            limit = {
+                var:token_charge <= 20
+            }
+            add_modifier = {
+                modifier = token_drained_modifier
+                years = 1
+            }
+        }
+        else = {
+            remove_modifier = token_drained_modifier
+        }
+
+        if = {
+            limit = {
+                var:token_charge >= 80
+            }
+            add_modifier = {
+                modifier = token_empowered_modifier
+                years = 1
+            }
+        }
+        else = {
+            remove_modifier = token_empowered_modifier
+        }
+    }
+}
+
+grant_pseudo_divinity_effect = {
+    # Check cap
+    if = {
+        limit = {
+            scope:actor.dynasty = {
+                any_dynasty_member = {
+                    count < 10
+                    OR = {
+                        has_trait = token_pseudo_divine
+                        has_trait = token_pseudo_divine_withered
+                    }
+                }
+            }
+        }
+        add_trait = token_pseudo_divine
+    }
+}

--- a/3411967296/common/traits/token_traits.txt
+++ b/3411967296/common/traits/token_traits.txt
@@ -1,0 +1,51 @@
+token_pseudo_divine = {
+    immortal = yes
+    no_prowess_loss_from_age = yes
+
+    diplomacy = 5
+    stewardship = 5
+    martial = 5
+    intrigue = 5
+    learning = 5
+    prowess = 10
+
+    health = 5
+
+    flag = pseudo_divinity
+    shown_in_ruler_designer = no
+
+    opposites = {
+        incapable
+        token_pseudo_divine_withered
+    }
+}
+
+token_pseudo_divine_withered = {
+    # Not immortal
+    # No buffs (or reduced buffs)
+
+    diplomacy = 2
+    stewardship = 2
+    martial = 2
+    intrigue = 2
+    learning = 2
+    prowess = 5
+
+    # Negative health handled by modifier
+
+    flag = pseudo_divinity
+    shown_in_ruler_designer = no
+
+    opposites = {
+        token_pseudo_divine
+    }
+}
+
+token_bearer = {
+    monthly_prestige = 1
+    same_faith_opinion = 10
+    dynasty_opinion = 10
+
+    flag = token_bearer
+    shown_in_ruler_designer = no
+}

--- a/3411967296/events/token_events.txt
+++ b/3411967296/events/token_events.txt
@@ -1,0 +1,69 @@
+namespace = token
+
+token.0001 = {
+    type = character_event
+    title = token.0001.t
+    desc = token.0001.desc
+    theme = mysticism
+
+    option = {
+        name = token.0001.a
+        add_prestige = 500
+    }
+}
+
+token.0010 = { # Ritual Success
+    type = character_event
+    title = token.0010.t
+    desc = token.0010.desc
+    theme = mysticism
+
+    option = {
+        name = token.0010.a
+    }
+}
+
+token.0020 = { # Sacrifice Success
+    type = character_event
+    title = token.0020.t
+    desc = token.0020.desc
+    theme = death
+
+    option = {
+        name = token.0020.a
+    }
+}
+
+token.1000 = {
+    type = character_event
+    hidden = yes
+
+    immediate = {
+        every_living_character = {
+            limit = {
+                OR = {
+                    has_trait = token_pseudo_divine
+                    has_trait = token_pseudo_divine_withered
+                }
+            }
+            check_token_region_effect = yes
+        }
+
+        every_living_character = {
+            limit = { has_trait = token_bearer }
+            update_token_charge_effect = yes
+        }
+    }
+}
+
+token.1001 = {
+    type = character_event
+    title = token.1001.t
+    desc = token.1001.desc
+    theme = health
+
+    option = {
+        name = token.1001.a
+        add_stress = 10
+    }
+}

--- a/3411967296/localization/english/token_l_english.yml
+++ b/3411967296/localization/english/token_l_english.yml
@@ -1,0 +1,51 @@
+l_english:
+ trait_token_pseudo_divine:0 "Pseudo-Divine"
+ trait_token_pseudo_divine_desc:0 "This character possesses a fragment of divine power, allowing them to live as a god among mortals. However, they are bound to the domain of the Token."
+
+ trait_token_pseudo_divine_withered:0 "Fading Divine"
+ trait_token_pseudo_divine_withered_desc:0 "The divine spark in this character is fading due to separation from the Token's domain. They are mortal once more."
+
+ trait_token_bearer:0 "Token Bearer"
+ trait_token_bearer_desc:0 "This character holds the Divine Token, the anchor of their family's power."
+
+ token_empowered_modifier:0 "Divine Surge"
+ token_drained_modifier:0 "Stretched Thin"
+ token_withered_modifier:0 "Withered by Mortality"
+
+ found_token_decision_title:0 "Forge the Divine Token"
+ found_token_decision_desc:0 "We have found the remnants of a slain god. With the right rituals, we can bind its power to our lineage and empire."
+ found_token_decision_tooltip:0 "Start the path of the Pseudo-Divine."
+
+ token_ritual_decision_title:0 "Perform Rejuvenation Ritual"
+ token_ritual_decision_desc:0 "The power of the Token wanes. We must immerse ourselves in the energies to restore it."
+ token_ritual_decision_tooltip:0 "Restore Token Charge."
+
+ token_sacrifice_decision_title:0 "Sacrificial Harvest"
+ token_sacrifice_decision_desc:0 "The Token is dying. Only blood can fuel it now."
+ token_sacrifice_decision_tooltip:0 "Sacrifice a prisoner to massively restore Charge."
+
+ destroy_token_decision_title:0 "Destroy the Token"
+ destroy_token_decision_desc:0 "This power is a curse. We must shatter the Token and return the energy to the cosmos."
+ destroy_token_decision_tooltip:0 "Ends the Pseudo-Divine path."
+
+ grant_pseudo_divinity_interaction:0 "Grant Divine Spark"
+ grant_pseudo_divinity_interaction_desc:0 "Share the power of the Token with a family member."
+
+ seize_token_interaction:0 "Seize the Token"
+ seize_token_interaction_desc:0 "The Bearer is weak. It is time to take the power for yourself."
+
+ token.0001.t:0 "The Vestige Found"
+ token.0001.desc:0 "We have secured the remains of the divine. The Token is forged, and power flows through our veins. We are now the masters of this domain."
+ token.0001.a:0 "We are Gods!"
+
+ token.0010.t:0 "Ritual Complete"
+ token.0010.desc:0 "The energies swirl and settle. The Token hums with renewed power."
+ token.0010.a:0 "Excellent."
+
+ token.0020.t:0 "Blood for Power"
+ token.0020.desc:0 "The life force of the sacrifice is consumed by the Token. It glows with a crimson light."
+ token.0020.a:0 "It is done."
+
+ token.1001.t:0 "The Withered Step"
+ token.1001.desc:0 "You have stepped beyond the domain of the Token. Your divine protection fades, and the weight of mortality crashes down upon you. Return to your lands, or perish!"
+ token.1001.a:0 "I feel... old."


### PR DESCRIPTION
Implemented the 'The Token' system as requested. 

Key components:
1.  **Traits:** `token_pseudo_divine` (Immortal), `token_pseudo_divine_withered` (Mortal), `token_bearer` (Owner).
2.  **Modifiers:** `token_empowered_modifier`, `token_drained_modifier`, `token_withered_modifier`.
3.  **Scripted Effects:** `token_effects.txt` handles creation, region checking, charging, and granting divinity.
4.  **Events:** `token_events.txt` handles creation, ritual success, and the yearly pulse for region locking.
5.  **Decisions:** `token_decisions.txt` allows forging the token (Empire Tier), performing rituals, and sacrificing prisoners.
6.  **Interactions:** `token_interactions.txt` allows granting divinity (hard cap logic included) and seizing the token.
7.  **Region Logic:** The Token is bound to the Empire title of the Bearer. Characters outside this de jure empire wither.

Addressed review feedback:
- Corrected interaction scoping for `grant_pseudo_divinity_effect`.
- Updated validity checks to include `withered` trait for the hard cap.
- Added logic to attempt clearing the old empire variable when the token is seized.

---
*PR created automatically by Jules for task [6296105213319258554](https://jules.google.com/task/6296105213319258554) started by @Bloodwarrior*