### PR TITLE
Fix script bugs in prayer effects and interactions

### DIFF
--- a/3411967296/common/character_interactions/divine_bless_interactions.txt
+++ b/3411967296/common/character_interactions/divine_bless_interactions.txt
@@ -139,7 +139,6 @@ bless_interaction = {
 			}
 			scope:recipient = { 
 				increase_beauty_rank_investment = {AMOUNT = 1}
-				choose_prayer_effect = yes
 			}
 		}
 

--- a/3411967296/common/script_values/power_costs_values.txt
+++ b/3411967296/common/script_values/power_costs_values.txt
@@ -103,45 +103,42 @@ curse_cost = {
 }
 
 health_powers_cost = {
-	{
+	add = {
+		desc = "BASE_VALUE"
+		value = 200
+		format = "BASE_VALUE_FORMAT"
+	}
+
+	if = {
+		limit = {
+			scope:severly_injure = yes
+		}
 		add = {
-			desc = "BASE_VALUE"
-			value = 200
-			format = "BASE_VALUE_FORMAT"
+			desc = "severly_injure_option"
+			value = 150
+			# format = "BASE_VALUE_FORMAT"
 		}
-
-		if = {
-			limit = {
-				scope:severly_injure = yes
-			}
-			add = {
-				desc = "severly_injure_option"
-				value = 150
-				# format = "BASE_VALUE_FORMAT"
-			}
+	}
+	if = {
+		limit = {
+			scope:smite = yes
 		}
-		if = {
-			limit = {
-				scope:smite = yes
-			}
-			add = {
-				desc = "smite_option"
-				value = 300
-				# format = "BASE_VALUE_FORMAT"
-			}
+		add = {
+			desc = "smite_option"
+			value = 300
+			# format = "BASE_VALUE_FORMAT"
 		}
-		scope:recipient = {
-			multiply = {
-				desc = "INVESTMENT_COST_MULTIPLY"
-				value = investment_level_multiplier
-			}
-		}
-
+	}
+	scope:recipient = {
 		multiply = {
-			desc = "DOMINION_COST_MULTIPLY"
-			value = dominion_multiplier
+			desc = "INVESTMENT_COST_MULTIPLY"
+			value = investment_level_multiplier
 		}
+	}
 
+	multiply = {
+		desc = "DOMINION_COST_MULTIPLY"
+		value = dominion_multiplier
 	}
 }
 

--- a/3411967296/common/scripted_effects/prayer_effects.txt
+++ b/3411967296/common/scripted_effects/prayer_effects.txt
@@ -498,7 +498,7 @@ choose_prayer_effect = {
 		3 = {
 			modifier = {
 				add = 10
-				has_trait = decietful
+				has_trait = deceitful
 			}
 			modifier = {
 				add = 10


### PR DESCRIPTION
Fixed a typo in `prayer_effects.txt` where `decietful` was used instead of `deceitful`.
Corrected a syntax error in `power_costs_values.txt` where `health_powers_cost` was wrapped in double braces.
Removed `choose_prayer_effect = yes` from `divine_bless_interactions.txt` for the beauty option, as it was lacking the required `scope:divinity` and likely unintended.

---
*PR created automatically by Jules for task [7004402183381317136](https://jules.google.com/task/7004402183381317136) started by @Bloodwarrior*